### PR TITLE
Remove unused includes from example

### DIFF
--- a/doc/examples/playlist_concat.c
+++ b/doc/examples/playlist_concat.c
@@ -9,9 +9,6 @@
 #include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>
 #include <libswresample/swresample.h>
-#include <libavutil/opt.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/audio_fifo.h>
 
 #define OUTPUT_WIDTH 1920
 #define OUTPUT_HEIGHT 1080


### PR DESCRIPTION
## Summary
- drop unused `libavutil/opt.h`, `libavutil/imgutils.h`, and `libavutil/audio_fifo.h` includes from `playlist_concat.c`

## Testing
- `./configure --disable-all`
- `make doc/examples/playlist_concat` *(fails: implicit declarations and missing struct members)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac49adf08323b83328051be180f2